### PR TITLE
workflow-templates: show previously invisible pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ KEYCLOAK_CLIENT_ID='finmars'
 APP_HOST='http://localhost:3000/v'
 API_HOST='https://stage.finmars.com'
 AUTH_HOST='https://stage.finmars.com/authorizer'
+EDITION_TYPE='community'
 
 OLD_APP_URL='http://0.0.0.0:8080/#!/'
 NUXT_HOST='localhost'

--- a/src/pages/workflow-template/index.vue
+++ b/src/pages/workflow-template/index.vue
@@ -45,7 +45,7 @@
 		<div class="flex mb-4">
 			<FmButton
 				class="button"
-				:type="currentPage === 1 ? 'disabled' : 'text'"
+				:type="currentPage === 1 ? 'disabled' : 'secondary'"
 				@click="openPreviousPage"
 			>
 				Previous
@@ -54,8 +54,7 @@
 			<div class="flex">
 				<div v-for="page in totalPages" :key="page">
 					<FmButton
-						v-if="totalPages > currentPage"
-						:type="currentPage === page && 'filled'"
+						:type="currentPage === page ? 'primary' : 'secondary'"
 						class="button"
 						@click="openPage(page)"
 					>
@@ -65,7 +64,7 @@
 			</div>
 			<FmButton
 				v-if="currentPage < totalPages"
-				type="text"
+				type="secondary"
 				class="button"
 				@click="openNextPage"
 			>


### PR DESCRIPTION
Previously, it was showing white text on a white background. This contrast ratio
wasn't particularly good. Applied button styles in line with workflow/index.vue,
so it is readable.

Moreover, the pagination buttons are no longer hidden on the last page.

https://github.com/finmars-platform/finmars-core/issues/77